### PR TITLE
Wire up browse and newsletter links in HeroSection

### DIFF
--- a/src/components/HeroSection/HeroSection.jsx
+++ b/src/components/HeroSection/HeroSection.jsx
@@ -7,16 +7,16 @@ const HeroSection = () => {
             <div className="cta-container">
                 {/* ----------- == NEXT ADVENTURE == --------------*/}
 
-                <a href="#" className="cta-card">
+                <Link to="/browse" className="cta-card">
                     <span className="cta-icon">🧭</span>
                     <h2 className="cta-title">Find Your Next Adventure</h2>
                     <p className="cta-sub">
                         Browse trails & hidden gems in your area.
                     </p>
-                </a>
+                </Link>
 
                 {/* ----------- == NEWS LETTER == --------------*/}
-                <a href="#" className="cta-card">
+                <Link to="/newsletter" className="cta-card">
                     <span className="cta-icon">📰</span>
                     <h2 className="cta-title">
                         Stay Informed: Join the Newsletter
@@ -24,7 +24,7 @@ const HeroSection = () => {
                     <p className="cta-sub">
                         Never miss local events, deals & safety updates.
                     </p>
-                </a>
+                </Link>
 
                 {/* ----------- == ADD ADVENTURE --------------*/}
 


### PR DESCRIPTION
- Replaced the “Find Your Next Adventure” card with a Link to /browse  
- Replaced the “Stay Informed: Join the Newsletter” card with a Link to /newsletter  
